### PR TITLE
Fixed typos and dataset link in A3 Jupyter_English

### DIFF
--- a/jupyter_english/assignments_fall2018/assignment3_decision_trees.ipynb
+++ b/jupyter_english/assignments_fall2018/assignment3_decision_trees.ipynb
@@ -195,8 +195,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2. Building a decision tree for predicting heart deseases\n",
-    "Let's read the data on heart deseases. "
+    "## 2. Building a decision tree for predicting heart diseases\n",
+    "Let's read the data on heart diseases. \n",
+    "The dataset can be downloaoded from https://github.com/Yorko/mlcourse.ai/blob/master/data/mlbootcamp5_train.csv by clicking on `Download` and then selecting `Save As` option."
    ]
   },
   {


### PR DESCRIPTION
The dataset link was missing for everyone in the Jupyter_English notebook of A3. 
The data was present in the data folder of the repository but for people like me that don't clone the whole repository, rather download only the notebook, it was missing.

Hence, I added the link to the data in the original repository and fixed some typos as well.