### PR TITLE
Update run_docker_jupyter.py for Docker Toolbox users on Windows

### DIFF
--- a/run_docker_jupyter.py
+++ b/run_docker_jupyter.py
@@ -1,21 +1,36 @@
 import os
 import argparse
 
+def path(): 
+	''' Special case for windows docker toolbox users.'''
+	path = os.getcwd()
+	if os.getenv('DOCKER_TOOLBOX_INSTALL_PATH') is not None:
+		if len(os.environ['DOCKER_TOOLBOX_INSTALL_PATH'])>0:
+			path = path.replace(':', '')
+			path = path.replace('\\\\', '/')
+			path = path.replace('\\', '/')
+			path = path.replace('C', 'c')
+			path = '/'+path
+	else: 
+		path = '"'+path+'"'
+	return path
+
+path = path()
+
 def main():
     parser = argparse.ArgumentParser(add_help=True, description='Run docker image.')
     parser.add_argument("--docker_tag", "-t", default='festline/mlcourse_ai', help='Docker image tag')
     parser.add_argument("--net_host", action='store_true', help='Whether to use --net=host with docker run (for Linux servers)')
     args = parser.parse_args()
 
-    run_command = 'docker run -it {0} --rm -p 5022:22 -p 4545:4545 -v "{1}":/notebooks -w /notebooks {2} jupyter'.format(
-        '--net=host' if args.net_host else '', os.getcwd(),  args.docker_tag)
+    run_command = 'docker run -it {0} --rm -p 5022:22 -p 4545:4545 -v {1}:/notebooks -w /notebooks {2} jupyter'.format(
+        '--net=host' if args.net_host else '', path,  args.docker_tag)
 
     print('Running command\n' + run_command)
     os.system(run_command)
 
 if __name__ == '__main__':
     main()
-
 
 
 


### PR DESCRIPTION
Many users have Win 10 Home, or Win 7 and Docker isn't available for them.
I had used Docker Toolbox instead and it works pretty well, but run_docker_jupyter.py doesn't works on it because Toolbox only has access to the C:\Users directory and mounts it into the VMs at /c/Users.
Note: Within the VM path, c is lowercase and the Users is capitalized.
https://docs.docker.com/toolbox/toolbox_install_windows/#looking-for-troubleshooting-help

While running this script on Docker Toolbox it raise error: docker: Error response from daemon: invalid mode: /notebooks.

Proposed changes fix this error. 
It were tested on Ubuntu + Docker: 
![worksonlinux](https://user-images.githubusercontent.com/31348740/47161232-4e2c8e80-d2fa-11e8-966a-5610adffd3ca.PNG)

and on Win 10 Home + Docker ToolBox
![workonwindows](https://user-images.githubusercontent.com/31348740/47161248-5ab0e700-d2fa-11e8-81bb-346a45c1bab1.PNG)

