### PR TITLE
Fixed a typo in the random forest notebook

### DIFF
--- a/jupyter_english/topic05_ensembles_random_forests/topic5_part2_random_forest.ipynb
+++ b/jupyter_english/topic05_ensembles_random_forests/topic5_part2_random_forest.ipynb
@@ -359,7 +359,7 @@
     "\n",
     "#### Practice with random forests in a real problem\n",
     " \n",
-    "We will use the problem of fraud detection as our example. This is a classification problem, and we will use accuracy for model evaluation.\n",
+    "In this example we will look at predicting customer churn. This is a classification problem, so we will use accuracy for model evaluation.\n",
     "\n",
     "First, let's build a simple classifier which we will use as a baseline. For the sake of simplicity, we will use only numeric features."
    ]


### PR DESCRIPTION
The example in the notebook is about customer churn and not fraud detection for this section. Looks like it's just a small typo.