### PR TITLE
typos in topic 10

### DIFF
--- a/jupyter_english/topic10_boosting/topic10_gradient_boosting.ipynb
+++ b/jupyter_english/topic10_boosting/topic10_gradient_boosting.ipynb
@@ -290,7 +290,7 @@
     "\n",
     "- $\\large L(y, f) = (y - f)^2$ a.k.a. $\\large L_2$ loss or Gaussian loss. It is the classical conditional mean, which is the simplest and most common case. If we do not have any additional information or requirements for a model to be robust, we can use the Gaussian loss.\n",
     "- $\\large L(y, f) = |y - f|$ a.k.a. $\\large L_1$ loss or Laplacian loss. At the first glance, this function does not seem to be differentiable, but it actually defines the conditional median. Median, as we know, is robust to outliers, which is why this loss function is better in some cases. The penalty for big variations is not as heavy as it is in $\\large L_2$.\n",
-    "- $ \\large \\begin{equation}  L(y, f) =\\left\\{   \\begin{array}{@{}ll@{}}     (1 - \\alpha) \\cdot |y - f|, & \\text{if}\\ |y-f| \\leq 0 \\\\     \\alpha \\cdot |y - f|, & \\text{if}\\ |y-f| >0  \\end{array}\\right. \\end{equation}, \\alpha \\in (0,1)\n",
+    "- $ \\large \\begin{equation}  L(y, f) =\\left\\{   \\begin{array}{@{}ll@{}}     (1 - \\alpha) \\cdot |y - f|, & \\text{if}\\ y-f \\leq 0 \\\\     \\alpha \\cdot |y - f|, & \\text{if}\\ y-f >0  \\end{array}\\right. \\end{equation}, \\alpha \\in (0,1)\n",
     "$ a.k.a. $\\large L_q$ loss or Quantile loss.  Instead of median, it uses quantiles. For example, $\\large \\alpha = 0.75$ corresponds to the 75%-quantile. We can see that this function is asymmetric and penalizes the observations which are on the right side of the defined quantile.\n",
     "\n",
     "<img src='https://habrastorage.org/web/6d5/e3a/09c/6d5e3a09c703491b947fde851e412ac0.png'>\n",
@@ -299,7 +299,7 @@
     "- Toy data $\\large \\left\\{ (x_i, y_i) \\right\\}_{i=1, \\ldots,300}$ ✓\n",
     "- A number of iterations $\\large M = 3$ ✓;\n",
     "- Loss function for quantiles $ \\large \\begin{equation}   L_{0.75}(y, f) =\\left\\{\n",
-    "\\begin{array}{@{}ll@{}}    0.25 \\cdot |y - f|, & \\text{if}\\ |y-f| \\leq 0 \\\\     0.75 \\cdot |y - f|, & \\text{if}\\ |y-f| >0   \\end{array}\\right. \\end{equation} $ ✓;\n",
+    "\\begin{array}{@{}ll@{}}    0.25 \\cdot |y - f|, & \\text{if}\\ y-f \\leq 0 \\\\     0.75 \\cdot |y - f|, & \\text{if}\\ y-f >0   \\end{array}\\right. \\end{equation} $ ✓;\n",
     "- Gradient $\\large L_{0.75}(y, f)$ - function weighted by $\\large \\alpha = 0.75$. We are going to train tree-based model for classification:\n",
     "$\\large r_{i} = -\\left[\\frac{\\partial L(y_i, f(x_i))}{\\partial f(x_i)}\\right]_{f(x)=\\hat{f}(x)} = $\n",
     "$\\large = \\alpha I(y_i > \\hat{f}(x_i) ) - (1 - \\alpha)I(y_i \\leq \\hat{f}(x_i) ), \\quad \\mbox{for } i=1,\\ldots,300$ ✓;\n",
@@ -315,7 +315,7 @@
     "The overall results of GBM with quantile loss function are the same as the results with quadratic loss function offset by $\\large \\approx 0.135$. But if we were to use the 90%-quantile, we would not have enough data due to the fact that classes would become unbalanced. We need to remember this when we deal with non-standard problems.\n",
     "\n",
     "<spoiler title=\"A few words regarding the regression loss functions\">\n",
-    "For regression tasks, many loss functions have been developed, some of them with extra properties. For example, they can be robust like in the [Huber loss function] (https://en.wikipedia.org/wiki/Huber_loss). For a small number of outliers, the loss function works as $\\large L_2$, but after a defined threshold, the function changes to $\\large L_1$. This allows for decreasing the effect of outliers and focusing on the overall picture.\n",
+    "For regression tasks, many loss functions have been developed, some of them with extra properties. For example, they can be robust like in the [Huber loss function](https://en.wikipedia.org/wiki/Huber_loss). For a small number of outliers, the loss function works as $\\large L_2$, but after a defined threshold, the function changes to $\\large L_1$. This allows for decreasing the effect of outliers and focusing on the overall picture.\n",
     "\n",
     "We can illustrate this with the following example. Data is generated from the function  $\\large y = \\frac{sin(x)}{x}$ with added noise, a mixture from normal and Bernulli distributions. We show the functions on graphs A-D and the relevant GBM on F-H (graph E represents the initial function):\n",
     "\n",
@@ -433,7 +433,6 @@
     "- “Gradient boosting machines, a tutorial”, [paper](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3885826/) by Alexey Natekin, and Alois Knoll\n",
     "- [Chapter in Elements of Statistical Learning](http://statweb.stanford.edu/~tibs/ElemStatLearn/printings/ESLII_print10.pdf) from Hastie, Tibshirani, Friedman (page 337)\n",
     "- [Wiki](https://en.wikipedia.org/wiki/Gradient_boosting) article about Gradient Boosting\n",
-    "- [Frontiers tutorial](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3885826/) article about GBM \n",
     "- [Video-lecture by Hastie](https://www.youtube.com/watch?v=wPqtzj5VZus) about GBM at h2o.ai conference"
    ]
   }


### PR DESCRIPTION
- typos in L_q loss definition
- markdown typo in Huber loss link
- remove duplicate entry in section 6 "Useful links"