### PR TITLE
t.6 texts feature extraction improvements

### DIFF
--- a/jupyter_english/topic06_features_regression/topic6_feature_engineering_feature_selection.ipynb
+++ b/jupyter_english/topic06_features_regression/topic6_feature_engineering_feature_selection.ipynb
@@ -92,7 +92,7 @@
     "\n",
     "After tokenization, you will normalize the data. For text, this is about stemming and/or lemmatization; these are similar processes used to process different forms of a word. One can read about the difference between them [here](http://nlp.stanford.edu/IR-book/html/htmledition/stemming-and-lemmatization-1.html).\n",
     "\n",
-    "So, now that we have turned the document into a sequence of words, we can represent it with vectors. The easiest approach is called Bag of Words: we create a vector with the length of the dictionary, compute the number of occurrences of each word in the text, and place that number of occurrences in the appropriate position in the vector. The process described looks simpler in code:"
+    "So, now that we have turned the document into a sequence of words, we can represent it with vectors. The easiest approach is called Bag of Words: we create a vector with the length of the vocabulary, compute the number of occurrences of each word in the text, and place that number of occurrences in the appropriate position in the vector. The process described looks simpler in code:"
    ]
   },
   {
@@ -116,18 +116,18 @@
     }
    ],
    "source": [
-    "from functools import reduce \n",
     "import numpy as np\n",
     "\n",
-    "texts = [['i', 'have', 'a', 'cat'], \n",
-    "        ['he', 'have', 'a', 'dog'], \n",
-    "        ['he', 'and', 'i', 'have', 'a', 'cat', 'and', 'a', 'dog']]\n",
+    "texts = ['i have a cat', \n",
+    "         'you have a dog', \n",
+    "         'you and i have a cat and a dog']\n",
     "\n",
-    "dictionary = list(enumerate(set(list(reduce(lambda x, y: x + y, texts)))))\n",
+    "vocabulary = list(enumerate(set([word for sentence in texts for word in sentence.split()])))\n",
+    "print('Vocabulary:', vocabulary)\n",
     "\n",
     "def vectorize(text): \n",
-    "    vector = np.zeros(len(dictionary)) \n",
-    "    for i, word in dictionary: \n",
+    "    vector = np.zeros(len(vocabulary)) \n",
+    "    for i, word in vocabulary:\n",
     "        num = 0 \n",
     "        for w in text: \n",
     "            if w == word: \n",
@@ -136,8 +136,9 @@
     "            vector[i] = num \n",
     "    return vector\n",
     "\n",
-    "for t in texts: \n",
-    "    print(vectorize(t))"
+    "print('Vectors:')\n",
+    "for sentence in texts: \n",
+    "    print(vectorize(sentence.split()))"
    ]
   },
   {
@@ -148,7 +149,7 @@
     "\n",
     "![image](../../img/bag_of_words.png)\n",
     "\n",
-    "This is an extremely naive implementation. In practice, you need to consider stop words, the maximum length of the dictionary, more efficient data structures (usually text data is converted to a sparse vector), etc.\n",
+    "This is an extremely naive implementation. In practice, you need to consider stop words, the maximum length of the vocabulary, more efficient data structures (usually text data is converted to a sparse vector), etc.\n",
     "\n",
     "When using algorithms like Bag of Words, we lose the order of the words in the text, which means that the texts \"i have no cows\" and \"no, i have cows\" will appear identical after vectorization when, in fact, they have the opposite meaning. To avoid this problem, we can revisit our tokenization step and use N-grams (the *sequence* of N consecutive tokens) instead."
    ]
@@ -319,7 +320,7 @@
     "\n",
     "$$ \\large tfidf(t,d,D) = tf(t,d) \\times idf(t,D) $$\n",
     "\n",
-    "Analogs of Bag of Words can be found outside of text problems e.g. bag of sites in the [Catch Me If You Can competition](https://inclass.kaggle.com/c/catch-me-if-you-can-intruder-detection-through-webpage-session-tracking), [bag of apps](https://www.kaggle.com/xiaoml/talkingdata-mobile-user-demographics/bag-of-app-id-python-2-27392), [bag of events](http://www.interdigital.com/download/58540a46e3b9659c9f000372), etc.\n",
+    "Similar to Bag of Words idea could be found outside of text problems e.g. bag of sites in the [Catch Me If You Can competition](https://inclass.kaggle.com/c/catch-me-if-you-can-intruder-detection-through-webpage-session-tracking), [bag of apps](https://www.kaggle.com/xiaoml/talkingdata-mobile-user-demographics/bag-of-app-id-python-2-27392), [bag of events](http://www.interdigital.com/download/58540a46e3b9659c9f000372), etc.\n",
     "\n",
     "![image](../../img/bag_of_words.png)\n",
     "\n",
@@ -1806,7 +1807,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.0"
+   "version": "3.6.5"
   },
   "toc": {
    "nav_menu": {},


### PR DESCRIPTION
I propose a few improvements:
1. Replace `reduce` with more pythonic approach - list comprehension (to flatten two level list). See:
https://stackoverflow.com/questions/952914/making-a-flat-list-out-of-list-of-lists-in-python
2. Use _vocabulary_ word instead of _dictionary_ because it's a) more suitable grammatically b) _dictionary_ may confuse people because it's usually treated as a data structure
3. Replace lists in `texts` with sentence string in order to reflect example in the corresponding image (though convert to list below)
4.  Few minor grammar improvements (including example in `texts` variable)
