### PR TITLE
Fix broken link to Ko-fi

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,4 +59,4 @@ Throughout the course we are maintaining a student rating. It takes into account
 ### Community
 Discussions between students are held in the **#mlcourse_ai** channel of the OpenDataScience Slack team. Fill in [this form](https://docs.google.com/forms/d/1BMqcUc-hIQXa0HB_Q2Oa8vWBtGHXk8a6xo5gPnMKYKA/edit) to get an invitation (prior to February 11, 2019). The form will also ask you some personal questions, don't hesitate :wave:
 
-*The course is free but you can support organizers by making a pledge on [Patreon](https://www.patreon.com/ods_mlcourse) (monthly support) or a one-time payment on [Ko-fi](ko-fi.com/mlcourse_ai). Thus you'll foster the spread of Machine Learning in the world!*
+*The course is free but you can support organizers by making a pledge on [Patreon](https://www.patreon.com/ods_mlcourse) (monthly support) or a one-time payment on [Ko-fi](https://ko-fi.com/mlcourse_ai). Thus you'll foster the spread of Machine Learning in the world!*


### PR DESCRIPTION
Fix broken link to Ko-fi in README.md
Link to Ko-fi at https://mlcourse.ai/contrib is also broken!