### PR TITLE
change DVC to DVC.org

### DIFF
--- a/jupyter_english/tutorials/tutorial_template.ipynb
+++ b/jupyter_english/tutorials/tutorial_template.ipynb
@@ -89,7 +89,7 @@
     "#### Other\n",
     " - A/B tests and interleaving\n",
     " - Bayesian methods of hyperparameter optimization\n",
-    " - Versioning datasets (ex. DVC)\n",
+    " - Versioning datasets (ex. DVC.org)\n",
     " - Optimizing non-trivial metrics: tips & tricks\n",
     " - Closer to business metrics: uplift modelling (pylift)"
    ]


### PR DESCRIPTION
Please change DVC to DVC.org. 
DVC.org is the current name of our product. 
Thank you! 