### PR TITLE
Fix "invalid reference format" for Docker container

### DIFF
--- a/run_docker_jupyter.sh
+++ b/run_docker_jupyter.sh
@@ -23,7 +23,7 @@ if [ $# -eq 0 ]; then
     docker pull $IMAGE
 fi
 
-exec docker run --rm -u $(id -u):$(id -g) -v $PWD:/notebooks -w /notebooks -e HOME=/notebooks/home -p $PORT:8888 $IMAGE jupyter-notebook --NotebookApp.ip=0.0.0.0 --NotebookApp.password_required=False --NotebookApp.token='' --NotebookApp.custom_display_url="http://localhost:$PORT"
+exec docker run --rm -u $(id -u):$(id -g) -v "$PWD:/notebooks" -w /notebooks -e HOME=/notebooks/home -p $PORT:8888 $IMAGE jupyter-notebook --NotebookApp.ip=0.0.0.0 --NotebookApp.password_required=False --NotebookApp.token='' --NotebookApp.custom_display_url="http://localhost:$PORT"
 
 # this allows for container to be created and persisted.
 # which means that you can keep the changes you made, 


### PR DESCRIPTION
If path of `$PWD` contains whitespaces, `-v $PWD:/notebooks` causes a `docker: invalid reference format: repository name must be lowercase` error.

This PR fixes the error with quoting the volume mapping flag for `run_docker_jupyter.sh` file.