### PR TITLE
A3, part 1, Q3: sparseness -> sparsity

### DIFF
--- a/jupyter_english/assignments_fall2019/assignment3_part1_alice_logistic_regression.ipynb
+++ b/jupyter_english/assignments_fall2019/assignment3_part1_alice_logistic_regression.ipynb
@@ -988,7 +988,7 @@
     "\n",
     "$$336\\ K * 48\\ K * 8\\ bytes \\approx 16* 10^9 * 8\\ bytes = 130\\ GB,$$\n",
     "\n",
-    "(that's the [exact](http://www.wolframalpha.com/input/?i=336358*48371*8+bytes) value). Obviously, ordinary mortals have no such volumes (strictly speaking, Python may allow you to create such a matrix, but it will not be easy to do anything with it). The interesting fact is that most of the elements of our matrix are zeros. If we count non-zero elements, then it will be about 1.8 million, i.е. slightly more than 10% of all matrix elements. Such a matrix, where most elements are zeros, is called sparse, and the ratio between the number of zero elements and the total number of elements is called the sparseness of the matrix.\n",
+    "(that's the [exact](http://www.wolframalpha.com/input/?i=336358*48371*8+bytes) value). Obviously, ordinary mortals have no such volumes (strictly speaking, Python may allow you to create such a matrix, but it will not be easy to do anything with it). The interesting fact is that most of the elements of our matrix are zeros. If we count non-zero elements, then it will be about 1.8 million, i.е. slightly more than 10% of all matrix elements. Such a matrix, where most elements are zeros, is called sparse, and the ratio between the number of zero elements and the total number of elements is called the sparsity of the matrix.\n",
     "\n",
     "For the work with such matrices you can use `scipy.sparse` library, check [documentation](https://docs.scipy.org/doc/scipy-0.18.1/reference/sparse.html) to understand what possible types of sparse matrices are, how to work with them and in which cases their usage is most effective. You can learn how they are arranged, for example, in Wikipedia [article](https://en.wikipedia.org/wiki/Sparse_matrix).\n",
     "Note, that a sparse matrix contains only non-zero elements, and you can get the allocated memory size like this (significant memory savings are obvious):"
@@ -1094,7 +1094,7 @@
    "source": [
     "As you might have noticed, there are not four columns in the resulting matrix (corresponding to number of different websites) but five. A zero column has been added, which indicates if the session was shorter (in our mini example we took sessions of three). This column is excessive and should be removed from the dataframe (do that yourself).\n",
     "\n",
-    "##### 3. What is the sparseness of the matrix in our small example?\n",
+    "##### 3. What is the sparsity of the matrix in our small example?\n",
     "\n",
     "*For discussions, please stick to [ODS Slack](https://opendatascience.slack.com/), channel #mlcourse_ai_news, pinned thread __#a3_part1_fall2019__*\n",
     "\n",


### PR DESCRIPTION
Hi!

I believe that there is a minor typo in Q3 of A3 part 1, according to [this](https://en.wikipedia.org/wiki/Sparse_matrix):

> The number of zero-valued elements divided by the total number of elements (e.g., m × n for an m × n matrix) is called the **sparsity** of the matrix (which is equal to 1 minus the density of the matrix).

So I've changed all occasions of sparseness to sparsity in this particular notebook.