### PR TITLE
FIX:  dataframe ix's are bad https://pandas.pydata.org/pandas-docs/version/0.23.4/gen…

### DIFF
--- a/jupyter_russian/topic04_linear_models/topic4_linear_models_part3_regul_example.ipynb
+++ b/jupyter_russian/topic04_linear_models/topic4_linear_models_part3_regul_example.ipynb
@@ -255,8 +255,8 @@
    },
    "outputs": [],
    "source": [
-    "X = data.ix[:,:2].values\n",
-    "y = data.ix[:,2].values"
+    "X = data.iloc[:,:2].values\n",
+    "y = data.iloc[:,2].values"
    ]
   },
   {


### PR DESCRIPTION
https://pandas.pydata.org/pandas-docs/version/0.23.4/generated/pandas.DataFrame.ix.html
contemporary pandas fails on using ix, here is switching to iloc