### PR TITLE
Adding correction to X_test

### DIFF
--- a/jupyter_english/assignments_demo/assignment03_decision_trees_solution.ipynb
+++ b/jupyter_english/assignments_demo/assignment03_decision_trees_solution.ipynb
@@ -925,6 +925,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "X_test = X_test[X_train.columns] # The feature names should match those that were passed during fit\n",
     "tree_predictions = tree.predict(X_test)"
    ]
   },
@@ -1168,7 +1169,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -1182,7 +1183,20 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.10.0"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
When the "Country_ Holand-Netherlands" column is added to X_test, it is added in the final column then X_test and X_train have differente order in their columns, therefore is important to "reorder" the columns before do the prediction for X_test. This change is inherent to the python version.