### PR TITLE
Modifying the code to resolve `FutureWarning` warning in `topic01_pan…

### DIFF
--- a/mlcourse_ai_jupyter_book/book/topic01/topic01_pandas_data_analysis.md
+++ b/mlcourse_ai_jupyter_book/book/topic01/topic01_pandas_data_analysis.md
@@ -316,7 +316,7 @@ Let’s do the same thing, but slightly differently by passing a list of functio
 ```{code-cell} ipython3
 columns_to_show = ["Total day minutes", "Total eve minutes", "Total night minutes"]
 
-df.groupby(["Churn"])[columns_to_show].agg([np.mean, np.std, np.min, np.max])
+df.groupby(["Churn"])[columns_to_show].agg(["mean", "std", "min", "max"])
 ```
 
 


### PR DESCRIPTION
Current implementation used `np.mean`, `np.std` etc, however, in future versions the same behavior can be observed just by passing `"mean"` instead of `np.mean`