### PR TITLE
Fix typo topic4 part5

### DIFF
--- a/jupyter_english/topic04_linear_models/topic4_linear_models_part2_logit_likelihood_learning.ipynb
+++ b/jupyter_english/topic04_linear_models/topic4_linear_models_part2_logit_likelihood_learning.ipynb
@@ -79,7 +79,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To predict the probability $p_+ \\in [0,1]$, we can start by constructing a linear prediction using OLS: $b(\\textbf{x}) = \\textbf{w}^\\text{T} \\textbf{x} \\in \\mathbb{R}$. But converting the resulting value to the probability within in the [0, 1] range requires some function $f: \\mathbb{R} \\rightarrow [0,1]$. Logistic regression uses a specific function for this: $\\sigma(z) = \\frac{1}{1 + \\exp^{-z}}$. Now let's understand what the prerequisites are.\n",
+    "To predict the probability $p_+ \\in [0,1]$, we can start by constructing a linear prediction using OLS: $b(\\textbf{x}) = \\textbf{w}^\\text{T} \\textbf{x} \\in \\mathbb{R}$. But converting the resulting value to the probability within the [0, 1] range requires some function $f: \\mathbb{R} \\rightarrow [0,1]$. Logistic regression uses a specific function for this: $\\sigma(z) = \\frac{1}{1 + \\exp^{-z}}$. Now let's understand what the prerequisites are.\n",
     "\n",
     "<img src='../../img/sigmoid.png' width=50% />"
    ]

--- a/jupyter_english/topic04_linear_models/topic4_linear_models_part5_valid_learning_curves.ipynb
+++ b/jupyter_english/topic04_linear_models/topic4_linear_models_part5_valid_learning_curves.ipynb
@@ -231,7 +231,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, what if we make the model even more complex by setting alpha = 10-4?\n",
+    "Now, what if we make the model even more complex by setting alpha = 1e-4?\n",
     "\n",
     "Overfitting is seen - AUC decreases on both the training and the validation sets."
    ]


### PR DESCRIPTION
Another typo fix.
"alpha = 10-4" -> "alpha = 1e-4"